### PR TITLE
revert: include 1.8.9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,8 +112,9 @@ val mappingConfig = buildMappingConfig {
         manifest
             .range("1.8.8", "1.20.5") { // change me
                 // exclude 1.16 and 1.10.1, they don't have most mappings and are basically not used at all
+                // exclude 1.8.9, client-only update - no Spigot mappings, no thank you
                 // exclude 1.9.1 and 1.9.3 - no mappings at all
-                exclude("1.16", "1.10.1", "1.9.1", "1.9.3")
+                exclude("1.16", "1.10.1", "1.8.9", "1.9.1", "1.9.3")
 
                 // include only releases, no snapshots
                 includeTypes(Version.Type.RELEASE)


### PR DESCRIPTION
Adding 1.8.9 has broken server-side mappings as it made it impossible to properly resolve the history between 1.8.8 and 1.9.